### PR TITLE
Switch over from authenticating with auth tokens to login tokens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/pyhq.py
+++ b/pyhq.py
@@ -1,4 +1,4 @@
-import json
+    import json
 import requests
 import re
 import datetime
@@ -295,10 +295,10 @@ def username_available(username: str) -> bool:
     return not bool(requests.post("https://api-quiz.hype.space/usernames/available", data={"username": username}).json())
 
 
-def create_user(username: str, verification_id: str, referral: str="", region: str="US"):
+def create_user(username: str, verification_id: str, referral: str="", region: str="US", language: str="en"):
     return requests.post("https://api-quiz.hype.space/users", data={
-        "country": "US",
-        "language": "en",
+        "country": region,
+        "language": language,
         "referringUsername": referral,
         "username": username,
         "verificationId": verification_id

--- a/pyhq.py
+++ b/pyhq.py
@@ -75,9 +75,9 @@ class HQClient:
             "user-agent": user_agent
         }
         self.ws = None
-        self.ws_on_message = lambda x: pass
-        self.ws_on_error = lambda x: pass
-        self.ws_on_close = lambda x: pass
+        self.ws_on_message = lambda x: None
+        self.ws_on_error = lambda x: None
+        self.ws_on_close = lambda x: None
         self.caching = caching # probably could just decorate but im too lazy
         self.cache_time = cache_time
         self._cache = {}

--- a/pyhq.py
+++ b/pyhq.py
@@ -209,7 +209,7 @@ class HQClient:
                 kwargs[_to_snake(k)] = v
             return HQPayout(**kwargs)
 
-    def addReferral(self, referral: str) -> bool:
+    def add_referral(self, referral: str) -> bool:
         return requests.patch("https://api-quiz.hype.space/users/me", headers=self.default_headers, data={"referringUsername": referral}).status_code == 200
 
     def schedule(self) -> dict:

--- a/pyhq.py
+++ b/pyhq.py
@@ -287,8 +287,8 @@ def verify(phone: str) -> str:
         raise Exception("invalid phone number")
 
 
-def submit_code(verification_id: str, code: str) -> bool:
-    return requests.post("https://api-quiz.hype.space/verifications/" + verification_id, data={"code": code}).status_code != 404
+def submit_code(verification_id: str, code: str) -> dict:
+    return requests.post("https://api-quiz.hype.space/verifications/" + verification_id, data={"code": code}).json()
 
 
 def username_available(username: str) -> bool:

--- a/pyhq.py
+++ b/pyhq.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import time
 from aws_requests_auth.aws_auth import AWSRequestsAuth
-from websocket import WebSocketApp, WebSocket
 
 _first_re = re.compile("(.)([A-Z][a-z]+)")
 _cap_re = re.compile("([a-z0-9])([A-Z])")

--- a/pyhq.py
+++ b/pyhq.py
@@ -78,7 +78,7 @@ class HQClient:
         self.ws_on_message = lambda x: None
         self.ws_on_error = lambda x: None
         self.ws_on_close = lambda x: None
-        self.caching = caching # probably could just decorate but im too lazy
+        self.caching = caching  # probably could just decorate but im too lazy
         self.cache_time = cache_time
         self._cache = {}
 
@@ -227,12 +227,15 @@ class HQClient:
         print(m)
         if socket is not None or m:
             if socket is None:
-                self.ws = WebSocketApp(schedule["broadcast"]["socketUrl"].replace("https", "wss"))
+                url = schedule["broadcast"]["socketUrl"]
             else:
-                self.ws = WebSocketApp(socket,
-                                       on_message=self.ws_on_message,
-                                       on_error=self.ws_on_error,
-                                       on_close=self.ws_on_close, header=["Authorization: " + self.auth_token])
+                url = socket[:]
+            url = url.replace("https", "wss")
+            print(url)
+            self.ws = WebSocketApp(url,
+                      on_message=self.ws_on_message,
+                      on_error=self.ws_on_error,
+                      on_close=self.ws_on_close, header=["Authorization: Bearer " + self.auth_token])
             self.wst = __import__("threading").Thread(target=self.ws.run_forever)
             self.wst.daemon = True
             self.wst.start()
@@ -269,6 +272,10 @@ class HQClient:
     def disconnect(self):
         self.ws.close()
         self.ws = None
+
+    def reconnect(self):
+        self.disconnect()
+        self.connect()
 
 
 def verify(phone: str) -> str:

--- a/pyhq.py
+++ b/pyhq.py
@@ -160,7 +160,7 @@ class HQClient:
         if self.caching:
             if "schedule" in self._cache:
                 if (time.time() - self._cache["schedule"]["last_update"]) < self.cache_time:
-                    return self._cache["schedule"]
+                    return self._cache["schedule"]["value"]
         ret = requests.get("https://api-quiz.hype.space/shows/now?type=hq", headers=self.default_headers).json()
         if self.caching:
             if "schedule" not in self._cache:

--- a/pyhq.py
+++ b/pyhq.py
@@ -345,9 +345,11 @@ class HQClient:
         })
 
 
-def verify(phone: str) -> str:
+def verify(phone: str, headers: dict={}) -> str:
     try:
-        return requests.post("https://api-quiz.hype.space/verifications", data={
+        return requests.post("https://api-quiz.hype.space/verifications", headers={
+            "x-hq-client": headers.get("x-hq-client") or "iOS/1.3.12 b96"
+        }, data={
             "method": "sms",
             "phone": phone
         }).json()["verificationId"]

--- a/pyhq.py
+++ b/pyhq.py
@@ -112,12 +112,13 @@ class HQPayoutInfo:
 
 
 class HQClient:
-    def __init__(self, auth_token: str, client: str="Android/1.6.2", user_agent: str="okhttp/3.8.0", caching=False, cache_time=15, no_ws_requests=False):
-        self.auth_token = auth_token
+    def __init__(self, login_token: str, client: str="Android/1.6.2", user_agent: str="okhttp/3.8.0", caching=False, cache_time=15, no_ws_requests=False):
+        self.login_token = login_token
         self.headers = {
             "x-hq-client": client,
             "user-agent": user_agent
         }
+        self.auth_token = self.get_auth_token()
         self.ws = None
         self.ws_on_message = lambda x: None
         self.ws_on_error = lambda x: None
@@ -134,6 +135,9 @@ class HQClient:
             "authorization": "Bearer " + self.auth_token,
             "user-agent": self.headers["user-agent"]
         }
+
+    def get_auth_token(self) -> str:
+        return requests.post("https://api-quiz.hype.space/tokens/", headers=self.headers, data={'token': self.login_token}).json()['authToken']
 
     def valid_auth(self) -> bool:
         return "active" in self.schedule()

--- a/pyhq.py
+++ b/pyhq.py
@@ -209,6 +209,9 @@ class HQClient:
                 kwargs[_to_snake(k)] = v
             return HQPayout(**kwargs)
 
+    def addReferral(self, referral: str) -> bool:
+        return requests.patch("https://api-quiz.hype.space/users/me", headers=self.default_headers, data={"referringUsername": referral}).status_code == 200
+
     def schedule(self) -> dict:
         if self.caching:
             if "schedule" in self._cache:

--- a/pyhq.py
+++ b/pyhq.py
@@ -4,7 +4,6 @@ import re
 import datetime
 import os
 import time
-from aws_requests_auth.aws_auth import AWSRequestsAuth
 
 _first_re = re.compile("(.)([A-Z][a-z]+)")
 _cap_re = re.compile("([a-z0-9])([A-Z])")

--- a/pyhq.py
+++ b/pyhq.py
@@ -1,0 +1,252 @@
+import json
+import requests
+import re
+import datetime
+import os
+import time
+from aws_requests_auth.aws_auth import AWSRequestsAuth
+from websocket import create_connection
+
+_first_re = re.compile("(.)([A-Z][a-z]+)")
+_cap_re = re.compile("([a-z0-9])([A-Z])")
+def _to_snake(name):
+    s1 = _first_re.sub(r"\1_\2", name)
+    return _cap_re.sub(r"\1_\2", s1).lower()
+
+
+class HQUserLeaderboard:
+    def __init__(self, **kwargs):
+        self.total_cents = kwargs.get("total_cents")
+        self.total = kwargs.get("total")
+        self.unclaimed = kwargs.get("unclaimed")
+        for p in ("alltime", "weekly"):
+            for v in ("wins", "total", "rank"):
+                try:
+                    setattr(self, f"{p}_{v}", kwargs.get(p).get(v))
+                except:
+                    pass
+
+
+class HQUserInfo:
+    def __init__(self, **kwargs):
+        self.user_id = kwargs.get("user_id")
+        self.username = kwargs.get("username")
+        self.avatar_url = kwargs.get("avatar_url")
+        self.created_timestamp = kwargs.get("created_timestamp")
+        self.broadcasts = kwargs.get("broadcasts")  # unused
+        self.featured = kwargs.get("featured")  # unused
+        self.referral_url = kwargs.get("referral_url")  # property?
+        self.high_score = kwargs.get("high_score")
+        self.games_played = kwargs.get("games_played")
+        self.win_count = kwargs.get("win_count") # different than leaderboard.alltime_wins cuz i dont know, i think this is the accurate one
+        self.blocked = kwargs.get("blocked")
+        self.blocks_me = kwargs.get("blocks_me")
+        try:
+            x = kwargs2.get("leaderboard")
+            if isinstance(x, dict):
+                kwargs2 = {}
+                for k, v in x.items():
+                    kwargs2[_to_snake(k)] = v
+                self.leaderboard = HQUserLeaderboard(**kwargs2)
+            elif isinstance(x, HQUserLeaderboard):
+                self.leaderboard = x
+        except Exception as e:
+            raise e
+
+
+class HQMeInfo(HQUserInfo):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.friend_ids = kwargs.get("friend_ids")
+        self.stk = kwargs.get("stk")  # unused?
+        self.voip = kwargs.get("voip")
+        self.device_tokens = kwargs.get("device_tokens")
+        self.preferences = kwargs.get("preferences")
+        self.lives = kwargs.get("lives")
+        self.phone_number = kwargs.get("phone_number")
+        self.referred = kwargs.get("referred")
+
+
+class HQClient:
+    def __init__(self, auth_token: str, client: str="Android/1.6.2", user_agent: str="okhttp/3.8.0", caching=False, cache_time=15):
+        self.auth_token = auth_token
+        self.headers = {
+            "x-hq-client": client,
+            "user-agent": user_agent
+        }
+        self.ws = None
+        self.caching = caching
+        self.cache_time = cache_time
+        self._cache = {}
+
+    @property
+    def default_headers(self) -> dict:
+        return {
+            "x-hq-client": self.headers["x-hq-client"],
+            "authorization": "Bearer " + self.auth_token,
+            "user-agent": self.headers["user-agent"]
+        }
+
+    def valid_auth(self) -> bool:
+        return "active" in self.schedule()
+
+    def make_it_rain(self) -> bool:
+        return requests.post("https://api-quiz.hype.space/easter-eggs/makeItRain", headers=self.default_headers).status_code == 200
+
+    def search_users(self, user: str) -> list:
+        response = requests.get("https://api-quiz.hype.space/users?q=" + user, headers=self.default_headers)
+        ret = []
+        for x in response.json()["data"]:
+            kwargs = {}
+            for k, v in x.items():
+                kwargs[_to_snake(k)] = v
+            ret.append(HQUserInfo(**kwargs))
+        return ret
+
+    def user_info(self, something) -> HQUserInfo:
+        if isinstance(something, str):
+            search = self.search_users(username)
+            if search:
+                raise Exception("User not found")
+            else:
+                user_id = search[0].user_id
+        elif isinstance(something, int):
+            user_id = something
+        response = requests.get("https://api-quiz.hype.space/users/me", headers=self.default_headers)
+        kwargs = {}
+        for k, v in response.json().items():
+            kwargs[_to_snake(k)] = v
+        ret = HQUserInfo(**kwargs)
+        if self.caching:
+            self._cache["user_info"][user_id] = {
+                "value": ret,
+                "last_update": time.time()
+            }
+        return ret
+
+    def me(self) -> HQMeInfo:
+        response = requests.get("https://api-quiz.hype.space/users/me", headers=self.default_headers)
+        kwargs = {}
+        for k, v in response.json().items():
+            kwargs[_to_snake(k)] = v
+            print(_to_snake(k), v)
+        return HQMeInfo(**kwargs)
+
+    def cashout(self, paypal: str) -> bool:
+        return requests.post("https://api-quiz.hype.space/users/me/payouts", headers=self.default_headers, data={"email": paypal}).status_code == 200
+
+    def schedule(self) -> dict:
+        return requests.get("https://api-quiz.hype.space/shows/now?type=hq", headers=self.default_headers).json()
+
+    def aws_credentials(self) -> dict:
+        return requests.get("https://api-quiz.hype.space/credentials/s3", headers=self.default_headers).json()
+
+    def delete_avatar(self) -> str:
+        return requests.delete("https://api-quiz.hype.space/users/me/avatarUrl", headers=self.default_headers).json()["avatarUrl"]
+
+    def subscribe(self) -> bool:
+        if self.ws is None:
+            return False
+        x = self.schedule()
+        self.ws.send(json.dumps({
+            "type": "subscribe",
+            "broadcastId": x["broadcast"]["broadcastId"]
+        }))
+        return True
+
+    def add_friend(self, something) -> dict:
+        if isinstance(something, int):
+            user_id = int(something)
+        elif isinstance(something, str):
+            search = self.search_users(something)
+            if search:
+                raise Exception("user not found")
+            user_id = search[0].user_id
+        elif isinstance(something, HQUserInfo):
+            user_id = something.user_id
+        response = requests.post(f"https://api-quiz.hype.space/friends/{user_id}/requests", headers=self.default_headers).json()
+        return {
+            "requested_user": self.user_info(response["requestedUser"]["userId"]),
+            "requesting_user": self.user_info(response["requestingUser"]["userId"]),
+            "status": response["status"]
+        }
+
+    def friend_status(self, something):
+        if isinstance(something, int):
+            user_id = int(something)
+        elif isinstance(something, str):
+            search = self.search_users(something)
+            if search:
+                raise Exception("user not found")
+            user_id = search[0].user_id
+        return requests.get(f"https://api-quiz.hype.space/friends/{user_id}/status", headers=self.default_headers).json()["status"]
+
+    def accept_friend(self, something) -> dict:
+        if isinstance(something, int):
+            user_id = int(something)
+        elif isinstance(something, str):
+            search = self.search_users(something)
+            if search:
+                raise Exception("user not found")
+            user_id = search[0].user_id
+        response = requests.put(f"https://api-quiz.hype.space/friends/{user_id}/status", headers=self.default_headers, data={
+                "status": "ACCEPTED"
+            }).json()
+        return {
+            "requested_user": self.user_info(response["requestedUser"]["userId"]),
+            "requesting_user": self.user_info(response["requestingUser"]["userId"]),
+            "status": response["status"],
+            "accepted_timestamp": response["created"]  # milliseconds(?)
+        }
+
+    def remove_friend(self, something) -> bool:
+        if isinstance(something, int):
+            user_id = int(something)
+        elif isinstance(something, str):
+            search = self.search_users(something)
+            if search:
+                raise Exception("user not found")
+            user_id = search[0].user_id
+        return requests.delete(f"https://api-quiz.hype.space/friends/{user_id}", headers=self.default_headers).json()["result"]
+
+    def connect(self, dont_subscribe: bool=False) -> bool:
+        schedule = self.schedule()
+        if isinstance("broadcast", dict):
+            self.ws = create_connection(schedule["broadcast"]["socketUrl"].replace("https", "wss"))
+            if not dont_subscribe:
+                self.subscribe()
+            return True
+        else:
+            return False
+
+    def disconnect(self):
+        self.ws.close()
+        self.ws = None
+
+
+def verify(phone: str) -> str:
+    try:
+        return requests.post("https://api-quiz.hype.space/verifications", data={
+            "method": "sms",
+            "phone": phone
+        }).json()["verificationId"]
+    except KeyError:
+        raise Exception("invalid phone number")
+
+
+def submit_code(verification_id: str, code: str) -> bool:
+    return requests.post("https://api-quiz.hype.space/verifications/" + verification_id, data={"code": code}).status_code != 404
+
+
+def username_available(username: str) -> bool:
+    return bool(requests.post("https://api-quiz.hype.space/usernames/available", data={"username": username}).json().keys())
+
+
+def create_user(username: str, verification_id: str, referral: str="", region: str="US"):
+    return requests.post("https://api-quiz.hype.space/users", data={
+        "country": "US",
+        "language": "en",
+        "referringUsername": referral,
+        "username": username,
+        "verificationId": verification_id
+    }).json()

--- a/pyhq.py
+++ b/pyhq.py
@@ -1,4 +1,4 @@
-    import json
+import json
 import requests
 import re
 import datetime


### PR DESCRIPTION
Login tokens are the better standard; they won't expire and are shorter in length.

This commit changes the default HQClient to accept a login token instead, and will automatically refresh and grab an auth token on creation.